### PR TITLE
Isomorphic testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+FROM node:6
+
+# Browser install from sitespeedio/docker-browsers
+
+ENV LC_ALL C
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+
+ENV FIREFOX_VERSION 45.7*
+ENV CHROME_VERSION 56.0.*
+
+# Avoid ERROR: invoke-rc.d: policy-rc.d denied execution of start.
+# Avoid ERROR: invoke-rc.d: unknown initscript, /etc/init.d/systemd-logind not found.
+
+RUN echo "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d && \
+    touch /etc/init.d/systemd-logind
+
+# Adding sudo for SLTC, lets see if we can find a better place (needed in Ubuntu 16)
+
+RUN apt-get update && \
+    apt-get install -y wget sudo --no-install-recommends && \
+    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+      echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list && \
+    apt-get update && \
+    apt-get install -y \
+    ca-certificates \
+    x11vnc \
+    libgl1-mesa-dri \
+    xfonts-100dpi \
+    xfonts-75dpi \
+    xfonts-scalable \
+    xfonts-cyrillic \
+    dbus-x11 \
+    xvfb --no-install-recommends && \
+    apt-get purge -y wget && \
+    apt-get install -y google-chrome-stable=${CHROME_VERSION} && \
+    apt-get install -y firefox-esr=${FIREFOX_VERSION} --no-install-recommends && \
+    apt-get clean autoclean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ADD ./start.sh /bin/xvfb_wrap
+RUN chmod +x /bin/xvfb_wrap
+
+WORKDIR /usr/src/app
+
+ENTRYPOINT ["/bin/xvfb_wrap", "npm", "test"]

--- a/package.json
+++ b/package.json
@@ -6,10 +6,17 @@
   "directories": {},
   "scripts": {
     "build": "browserify lib/index.js > storj.es6.js # && babel storj.es6.js > storj.es5.js",
-    "pretest": "eslint --fix .",
-    "test": "nyc --reporter=text --reporter=html tape test/**/*.js #&& testling",
+    "posttest": "eslint --fix .",
+    "test": "npm run test-node && npm run test-browser",
+    "test-node": "nyc --reporter=text --reporter=html tape test/**/*.js",
+    "test-browser": "testling",
     "make-docs": "rm -rf ./jsdoc && ./node_modules/.bin/jsdoc lib -r -R README.md -c .jsdoc.json --verbose -d ./jsdoc",
     "node-test": "node test/**/*.js"
+  },
+  "browserify": {
+    "transform": [
+      "envify"
+    ]
   },
   "testling": {
     "files": [
@@ -28,6 +35,7 @@
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "browserify": "^13.1.1",
+    "envify": "^4.0.0",
     "eslint": "^3.14.0",
     "ink-docstrap": "bookchin/docstrap",
     "jsdoc": "^3.4.3",

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Startup script from sitespeedio/sitespeed.io-docker
+set -e
+date
+# print versions
+google-chrome-stable --version
+# Starting Firefox will get us this message
+# GLib-CRITICAL **: g_slice_set_config: assertion 'sys_page_size == 0' failed
+# https://bugzilla.mozilla.org/show_bug.cgi?id=833117
+# firefox -version
+firefox --version 2>/dev/null
+echo 'Starting Xvfb ...'
+export DISPLAY=:99
+2>/dev/null 1>&2 Xvfb :99 -shmem -screen 0 1366x768x16 &
+exec "$@"

--- a/test/000_runfirst.js
+++ b/test/000_runfirst.js
@@ -1,0 +1,31 @@
+/**
+ * This file is prefixed with 000_ to ensure it runs before all of the other
+ * tests when the glob patter is expanded. This ensures we catch missing env
+ * vars before the tests blowup with weird error messages
+ */
+'use strict'
+
+var test = require('tape');
+
+if(process.env.STORJ_USERNAME === undefined) {
+  throw new Error('Must set STORJ_USERNAME to run tests');
+}
+
+var user = process.env.STORJ_USERNAME;
+
+if(process.env.STORJ_PASSWORD === undefined) {
+  throw new Error('Must set STORJ_PASSWORD to run tests');
+}
+
+var pass = process.env.STORJ_PASSWORD;
+
+if(process.env.STORJ_BRIDGE === undefined) {
+  throw new Error('Must set STORJ_BRIDGE to run tests');
+}
+
+var bridge = process.env.STORJ_BRIDGE;
+
+test('Valid environment', function(t) {
+  t.comment(`Running with ${user}:${pass}@${bridge}`);
+  t.end();
+});


### PR DESCRIPTION
Uses browserify to bundle the tests and testling to execute them in the
first available browser it finds. Later we can expand this to test
multiple versions of multiple browsers in CI/CD.

envify will inject the environment variables necessesary for testing
into the browserified bundle for browser testing, thus bypassing `process.env`.