### PR TITLE
appendTo fixes

### DIFF
--- a/lib/api/createFile.js
+++ b/lib/api/createFile.js
@@ -85,7 +85,7 @@ module.exports = function createFile(bucketId, fileName, file, opts, cb) {
     });
 
     storeStream.on('finish', function() {
-      f.size = fileSize;
+      f.length = fileSize;
       var encryptedStream = self._store.createReadStream(f._storeKey);
       var clientOpts = { fileSize, fileName }
       self._client.storeFileInBucket(
@@ -100,6 +100,14 @@ module.exports = function createFile(bucketId, fileName, file, opts, cb) {
           // necessarily transfering data. File.progress will be more
           // meaningful in the future.
           f.progress = 1;
+
+          // Update attributes off of resp
+          f.mimetype = resp.mimetype;
+
+          // If our name was already taken, bridge will generate a name for us,
+          // update f.name and f.id to reflect bridge's state
+          f.name = resp.name;
+          f.id = resp.id;
 
           return f.emit('done', resp);
         }

--- a/lib/api/getFile.js
+++ b/lib/api/getFile.js
@@ -23,7 +23,8 @@ module.exports = function getFile(bucketId, fileId, cb) {
       return f.emit('error', e);
     }
 
-    f.mimetype = p.token.mimetype;
+    f.mimetype = p.metadata.mimetype;
+    f.name = p.metadata.filename;
 
     // Determine the key for decrypting the file
     if(p.token.encryptionKey !== '') {
@@ -48,7 +49,7 @@ module.exports = function getFile(bucketId, fileId, cb) {
     f.secret = new DeterministicKeyIv(f.key, f.id);
 
     // Compute the total size of the file encrypted
-    f.size = p.pointers.reduce((p, c) => p += c.size, 0);
+    f.length = p.pointers.reduce((p, c) => p += c.size, 0);
     f.downloaded = 0;
 
     // Track the size of the unencrypted file
@@ -67,7 +68,7 @@ module.exports = function getFile(bucketId, fileId, cb) {
       // Track download progress
       file.on('data', function(d) {
         f.downloaded += d.length;
-        f.progress = f.downloaded / f.size;
+        f.progress = f.downloaded / f.length;
       });
 
       decrypter.on('data', function(d) {
@@ -76,7 +77,8 @@ module.exports = function getFile(bucketId, fileId, cb) {
 
       storeStream.on('finish', function() {
         // Update size to reflect decrypted file
-        f.size = f._size;
+        f.length = f._size;
+        delete f._size;
         f.emit('done');
       });
 

--- a/lib/api/getFilePointers.js
+++ b/lib/api/getFilePointers.js
@@ -4,15 +4,24 @@ module.exports = function getFilePointers(bucketId, fileId, cb) {
   var self = this;
   var result = {}
 
-  self._client.createToken(bucketId, 'PULL', function token(e, token) {
+  self._client.getFileInfo(bucketId, fileId, function metadata(e, metadata) {
     if(e) {
       return cb(e);
     }
-    result.token = token;
-    var clientOpts = { bucket: bucketId, file: fileId, token: token.token };
-    self._client.getFilePointers(clientOpts, function pointers(e, pointers){
-      result.pointers = pointers;
-      return cb(null, result);
-    })
+    result.metadata = metadata
+    self._client.createToken(bucketId, 'PULL', function token(e, token) {
+      if(e) {
+        return cb(e);
+      }
+      result.token = token;
+      var clientOpts = { bucket: bucketId, file: fileId, token: token.token };
+      self._client.getFilePointers(clientOpts, function pointers(e, pointers){
+        if(e) {
+          return cb(e);
+        }
+        result.pointers = pointers;
+        return cb(null, result);
+      });
+    });
   });
 }

--- a/lib/file.js
+++ b/lib/file.js
@@ -98,7 +98,7 @@ File.Defaults = {
  */
 
 File.prototype.getBuffer = function getBuffer(cb) {
-  return streamToBuffer(this.createReadStream(), this.size, cb);
+  return streamToBuffer(this.createReadStream(), this.length, cb);
 };
 
 File.prototype.createReadStream = function getReadStream() {
@@ -106,11 +106,12 @@ File.prototype.createReadStream = function getReadStream() {
 }
 
 File.prototype.appendTo = function appendTo(rootElem, cb) {
+  var self = this;
   cb = cb || function () {};
   var file = {
-    name: `file${self._getExtension()}`,
+    name: self.name,
     createReadStream: function() {
-      return this.createReadStream();
+      return self.createReadStream();
     }
   };
   render.append(file, rootElem, cb);

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "fs-blob-store": "^5.2.1",
     "local-web-server": "^1.2.6",
     "memory-blob-store": "^5.0.1",
-    "render-media": "^2.9.1",
+    "render-media": "github:retrohacker/render-media",
     "setimmediate": "^1.0.5",
     "storj-lib": "^6.3.2",
     "stream-to-blob": "^1.0.0",

--- a/test/all/index.js
+++ b/test/all/index.js
@@ -64,7 +64,6 @@ test('Storj.generateEncryptionKey', function(t) {
 });
 
 test('Constructor with key', function(t) {
-  console.log(mnemonic)
   storj = new Storj({
     bridge: process.env.STORJ_BRIDGE,
     key: key.getPrivateKey(),
@@ -132,8 +131,9 @@ test('createFile', function(t) {
   file.on('error', t.fail)
   file.on('done', function() {
     t.ok(emittedReady, 'file emitted ready before done');
-    t.equal(file.size, fileContent.length,
-      'expect size to be length of fileContent');
+    t.equal(file.length, fileContent.length,
+      'expect length to be length of fileContent');
+    t.equal(file.mimetype, 'text/plain', 'expect .txt mimetype');
     fileId = file.id;
     t.equal(file.progress, 1, 'file.progress shows complete');
     t.end();
@@ -158,6 +158,8 @@ test('getFile', function(t) {
   let file;
   const handler = function() {
     t.equal(file.id, fileId, 'file.id populated');
+    t.equal(file.name, fileName, 'file name populated');
+    t.equal(file.mimetype, 'text/plain', 'mimetype for .txt set');
     t.equal(file.progress, 1, 'file.progress shows complete');
     file.getBuffer(function (e, buffer) {
       t.error(e, 'retreived file contents');


### PR DESCRIPTION
* `file.size` -> `file.length` to stay in line with documentation
* `file.mimetype` now properly set
* `file.id` and `file.name` updated after succesful upload to match how the file was stored on the bridge
* appendTo now properly scopes `this` via `var self`
* Remove recursive call to `createReadableStream` from `appendTo`
* Remove temporary variable file._size in getFile
* Add tests for all File API metadata attributes
* Remove extra `console.log` statements
* `getFilePointers` now properly returns an error if `BridgeClient.getFilePointers` fails
* `getFilePointers` now fetches file metadata
* `getFile` now uses `metadata` property from `getFilePointers` to populate `mimetype` and `name`
* `appendTo` now users `file.name` instead of attempting to derive the extension from the mimetype
* `render-media` now supports `svg` image type
* Update tests to assert behaviour
* `svg` in test requires `xmlns` to render
* `SETUP` and `TEARDOWN` in `./test/browser/index.js` now throw on errors