### PR TITLE
Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ Return a readable stream of decrypted data being pulled directly from farmers. T
 storj.download(fileId, bucketId).pipe(fs.createWriteStream('cat.jpg'));
 ```
 
-### `var stream = storj.upload(bucketId, fileName, opts)`
+### `var stream = storj.upload(bucketId, fileName)`
 
 Return a writable stream. When written to, the data will be encrypted and uploaded to the storj network.
 

--- a/lib/api/upload.js
+++ b/lib/api/upload.js
@@ -13,16 +13,10 @@ var through = require('through');
 var DeterministicKeyIv =
   require('storj-lib/lib/crypto-tools/deterministic-key-iv');
 
-module.exports = function(bucketId, fileName, opts, cb) {
+module.exports = function(bucketId, fileName) {
   var self = this;
 
   var uploadMeta = {};
-
-  // Make opts optional
-  if(cb === undefined && typeof opts === 'function') {
-    cb = opts;
-    opts = {};
-  }
 
   uploadMeta.id = storjUtils.calculateFileId(bucketId, fileName);
   uploadMeta.fileName = fileName;

--- a/test/all/index.js
+++ b/test/all/index.js
@@ -229,6 +229,19 @@ test('deleteFile', function(t) {
   });
 });
 
+test('getFileList', function(t) {
+  storj.getFileList(bucketId, function(e, files) {
+    t.error(e, 'fetch file list successfully');
+    for(var i = 0; i < files.length; i++) {
+      if(files[i].filename === fileName) {
+        t.fail('file remained after delete');
+      }
+    }
+    t.pass('file removed');
+    return t.end();
+  });
+});
+
 test('upload', function(t) {
   var encrypted =false;
   var stored = false;
@@ -236,7 +249,7 @@ test('upload', function(t) {
   rs._read = function() {};
   rs.push(fileContent);
   rs.push(null);
-  const uploadStream = storj.upload(bucketId, fileName);
+  const uploadStream = storj.upload(bucketId, `stream-${fileName}`);
   rs.pipe(uploadStream);
   t.equal(uploadStream.readable, true, 'returned stream is readable');
   t.equal(uploadStream.writable, true, 'returned stream is writable');
@@ -247,9 +260,10 @@ test('upload', function(t) {
     stored = true;
   });
   uploadStream.on('error', t.fail)
-  uploadStream.on('done', function() {
+  uploadStream.on('done', function(metadata) {
     t.equal(stored, true, 'store finished getting encrypted file');
     t.equal(encrypted, true, 'stream finished encrypting the file');
+    fileId = metadata.id;
     t.end();
   });
 });
@@ -270,19 +284,6 @@ test('deleteFile', function(t) {
   storj.deleteFile(bucketId, fileId, function (e) {
     t.error(e, 'removed file');
     t.end();
-  });
-});
-
-test('getFileList', function(t) {
-  storj.getFileList(bucketId, function(e, files) {
-    t.error(e, 'fetch file list successfully');
-    for(var i = 0; i < files.length; i++) {
-      if(files[i].filename === fileName) {
-        t.fail('file remained after delete');
-      }
-    }
-    t.pass('file removed');
-    return t.end();
   });
 });
 

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -173,10 +173,6 @@ test('Browser: deleteFile', function(t) {
   storj.deleteFile(bucketId, fileId, t.end);
 });
 
-test('Browser: deleteFile', function(t) {
-  storj.deleteFile(bucketId, fileId, t.end);
-});
-
 test('Browser: deleteBucket', function(t) {
   storj.deleteBucket(bucketId, function (e) {
     t.end(e);


### PR DESCRIPTION
:twitch:

* Remove unused `opts` from `storj.upload`
* Remove unused `cb` from `storj.upload`
* Move `getFileList` up to verify first `delete`
* Reuse `fileContent` and `fileName` in `storj.upload`/`storj.download` tests
* Remove extra `Browser: deleteFile` test